### PR TITLE
fix(workstation): stabilize Alma9 Brave and VAAPI setup

### DIFF
--- a/docs/maintainers/workstation-layering.md
+++ b/docs/maintainers/workstation-layering.md
@@ -38,17 +38,18 @@ The system Flatpak policy is intentionally opinionated. It keeps managed shared 
 It includes:
 
 - `workstation-substrate.yml`: shared desktop, hardware, input, audio, printing, scanning, camera, language, and base workstation package substrate
+- `workstation-media.yml`: shared distro-native VAAPI/media runtime packages; distro/vendor-specific diagnostics and backends stay in distro or driver layers
 - `workstation-admin-tools.yml`: workstation-only diagnostics, storage, network, and admin utilities
 - `workstation-policy.yml`: graphical target, display-manager reconciliation, and workstation sleep policy
-- `workstation-user-tools.yml`: opinionated user-facing workstation tooling such as Homebrew and Brave Origin Beta
+- `workstation-user-tools.yml`: opinionated user-facing workstation tooling such as Homebrew and Brave Origin
 
 This prevents GNOME and COSMIC from duplicating the same substrate while keeping workstation product opinions visible and reviewable.
 
-## Brave Origin Beta
+## Brave Origin
 
-Brave Origin Beta is intentionally shipped in workstation images from the RPM repository because it is not available through Flathub.
+Brave Origin is intentionally shipped in workstation images from the RPM repository because it is not available through Flathub.
 
-That is a product opinion, not an accidental dependency. Keep it in `workstation-user-tools.yml` so the opinion stays explicit.
+That is a product opinion, not an accidental dependency. Keep it in `workstation-user-tools.yml` so the opinion stays explicit. The same layer owns the bootc `/opt` compatibility tmpfiles rule that recreates `/var/opt/brave.com -> /usr/lib/opt/brave.com` on boot, because Brave still expects its vendor payload at `/opt/brave.com` while bootc deployments expose package-owned `/opt` content through `/usr/lib/opt`.
 
 ## GNOME layering
 
@@ -85,4 +86,8 @@ COSMIC-specific behavior such as greeter wiring, session bits, common packages, 
 
 `recipes/layers/shared/nvidia-workstation.yml` remains the shared workstation-display NVIDIA add-on for both environments.
 
-That keeps display/session NVIDIA extras separate from the core lane plumbing in the shared NVIDIA layers.
+Alma 9 also adds `libva-utils` in `recipes/layers/alma9/workstation.yml` because EPEL 9 provides `vainfo` there while current EPEL 10 metadata does not. Keep the shared `workstation-media.yml` layer limited to media runtime packages available across supported workstation lanes.
+
+Alma 9 NVIDIA workstations add `recipes/layers/alma9/nvidia-workstation.yml` for the EPEL `libva-nvidia-driver` VAAPI backend. That layer is deliberately not included by the Alma 9 NVIDIA server recipe.
+
+That keeps display/session and browser/media NVIDIA extras separate from the core lane plumbing in the shared NVIDIA layers.

--- a/files/workstation/user-tools/usr/lib/tmpfiles.d/myos-brave-origin-opt.conf
+++ b/files/workstation/user-tools/usr/lib/tmpfiles.d/myos-brave-origin-opt.conf
@@ -1,0 +1,5 @@
+# Brave Origin's RPM owns /opt/brave.com. bootc/rpm-ostree stores packaged
+# /opt payloads under /usr/lib/opt while /opt resolves through writable /var/opt.
+# Recreate the compatibility link at boot for new and existing deployments.
+d /var/opt 0755 root root -
+L+ /var/opt/brave.com - - - - /usr/lib/opt/brave.com

--- a/recipes/images/workstation/cosmic/alma9/core-nvidia-580.yml
+++ b/recipes/images/workstation/cosmic/alma9/core-nvidia-580.yml
@@ -15,5 +15,6 @@ modules:
   - from-file: layers/alma/cosmic.yml
   - from-file: layers/shared/workstation-cosmic.yml
   - from-file: layers/shared/nvidia-workstation.yml
+  - from-file: layers/alma9/nvidia-workstation.yml
   - type: initramfs
   - type: signing

--- a/recipes/images/workstation/gnome/alma9/core-nvidia-580.yml
+++ b/recipes/images/workstation/gnome/alma9/core-nvidia-580.yml
@@ -15,5 +15,6 @@ modules:
   - from-file: layers/shared/workstation-gnome.yml
   - from-file: layers/alma9/gnome.yml
   - from-file: layers/shared/nvidia-workstation.yml
+  - from-file: layers/alma9/nvidia-workstation.yml
   - type: initramfs
   - type: signing

--- a/recipes/layers/README.md
+++ b/recipes/layers/README.md
@@ -14,7 +14,8 @@ These files are the reusable composition units included from image recipes with 
 - `shared/flatpak-gnome.yml`: GNOME portal backend configuration and GNOME-specific managed Flatpaks.
 - `shared/flatpak-gnome-legacy.yml`: Alma 9 GNOME managed Flatpak app delta for apps provided natively on modern GNOME lanes.
 - `shared/flatpak-cosmic.yml`: COSMIC portal backend configuration and COSMIC Flatpak remotes.
-- `shared/workstation-common.yml`: DE-agnostic workstation substrate.
+- `shared/workstation-common.yml`: DE-agnostic workstation orchestrator.
+- `shared/workstation-media.yml`: shared workstation media/VAAPI runtime baseline; distro/vendor-specific diagnostics and backends remain in their distro or driver layers.
 - `shared/workstation-modern.yml`: shared workstation delta reused by the Alma 10 and Fedora lanes.
 - `shared/workstation-gnome.yml`: GNOME workstation layer.
 - `shared/workstation-gnome-modern.yml`: shared GNOME app delta reused by the Alma 10 and Fedora lanes.
@@ -29,7 +30,8 @@ These files are the reusable composition units included from image recipes with 
 - `alma9/gnome.yml`, `alma10/gnome.yml`: GNOME-only distro drift where the shared GNOME layers are not enough.
 - `alma/cosmic.yml`: Alma-family COSMIC COPR source setup and COPR-backed applets shared by Alma 9 and Alma 10.
 - `fedora/cosmic.yml`, `fedora/nvidia-open.yml`: Fedora edge-lane drift.
-- `alma9/nvidia-580.yml`: the Alma 9 implementation of the public NVIDIA 580 lane.
+- `alma9/nvidia-580.yml`: the Alma 9 implementation of the public NVIDIA 580 lane shared by server and workstation images.
+- `alma9/nvidia-workstation.yml`: Alma 9 NVIDIA workstation-only media backend additions, kept out of the server lane.
 
 ## Feature layers
 

--- a/recipes/layers/alma9/nvidia-workstation.yml
+++ b/recipes/layers/alma9/nvidia-workstation.yml
@@ -1,0 +1,12 @@
+modules:
+  # Workstation-only VAAPI backend for the Alma 9 NVIDIA 580 lane.
+  #
+  # EPEL's libva-nvidia-driver supplies nvidia_drv_video.so. Do not set
+  # LIBVA_DRIVER_NAME globally here; multi-GPU systems may have AMD/Intel as
+  # the primary render node and should let libva/browser policy select per
+  # device/session.
+  - type: dnf
+    install:
+      install-weak-deps: false
+      packages:
+        - libva-nvidia-driver

--- a/recipes/layers/alma9/workstation.yml
+++ b/recipes/layers/alma9/workstation.yml
@@ -7,5 +7,6 @@ modules:
         - almalinux-release
         - google-noto-cjk-fonts-common
         - google-noto-fonts-common
+        - libva-utils
         - systemd-oomd
         - xorg-x11-utils

--- a/recipes/layers/shared/workstation-common.yml
+++ b/recipes/layers/shared/workstation-common.yml
@@ -10,6 +10,7 @@ modules:
   # - DE-specific session logic comes from workstation-gnome.yml or
   #   workstation-cosmic.yml later in the image recipe
   - from-file: layers/shared/workstation-substrate.yml
+  - from-file: layers/shared/workstation-media.yml
 
   - type: files
     files:

--- a/recipes/layers/shared/workstation-media.yml
+++ b/recipes/layers/shared/workstation-media.yml
@@ -1,0 +1,13 @@
+modules:
+  # DE-agnostic media acceleration runtime shared by workstation images.
+  #
+  # Keep this layer to distro-native packages that are available across the
+  # supported workstation lanes. Distro/vendor-specific diagnostics and VAAPI
+  # backends stay in their Alma/Fedora/NVIDIA layers.
+  - type: dnf
+    install:
+      install-weak-deps: false
+      packages:
+        - libva
+        - libvdpau
+        - mesa-dri-drivers

--- a/recipes/layers/shared/workstation-user-tools.yml
+++ b/recipes/layers/shared/workstation-user-tools.yml
@@ -2,6 +2,12 @@ modules:
   - type: brew
     nofile-limits: true
     brew-analytics: false
+
+  - type: files
+    files:
+      - source: workstation/user-tools
+        destination: /
+
   - type: containerfile
     snippets:
       # Legacy validation marker: brave-origin-beta was replaced by brave-origin release.

--- a/scripts/validate-image-matrix.sh
+++ b/scripts/validate-image-matrix.sh
@@ -104,6 +104,7 @@ platform_ceph_layers = {
     'fedora': root / 'recipes/layers/fedora/ceph-host.yml',
 }
 nvidia_base = root / 'recipes/layers/shared/nvidia-base.yml'
+alma9_nvidia_workstation = root / 'recipes/layers/alma9/nvidia-workstation.yml'
 recipe_ymls = sorted((root / 'recipes').rglob('*.yml'))
 alma_only_shared_patterns = {
     'epel-release': 'EPEL is Alma/RHEL-family repository setup; use layers/alma/core.yml',
@@ -223,6 +224,13 @@ for row in rows:
             die(f"standard image {row['image']} must not include shared/nvidia-base.yml")
     elif nvidia_count != 1:
         die(f"NVIDIA image {row['image']} must include shared/nvidia-base.yml exactly once")
+
+    alma9_nvidia_workstation_count = graph.count(alma9_nvidia_workstation)
+    if row['platform'] == 'alma9' and row['driver'] == 'nvidia-580' and row['role'] == 'workstation':
+        if alma9_nvidia_workstation_count != 1:
+            die(f"Alma 9 NVIDIA workstation {row['image']} must include alma9/nvidia-workstation.yml exactly once")
+    elif alma9_nvidia_workstation_count != 0:
+        die(f"Image {row['image']} must not include Alma 9 NVIDIA workstation-only media backend layer")
 
 expected_singletons = {
     'pcp package': (r'^\s*-\s+pcp\s*$', 1),

--- a/scripts/validate-runtime-artifacts.sh
+++ b/scripts/validate-runtime-artifacts.sh
@@ -64,15 +64,24 @@ grep -q "myos-flatpak-system-maintenance ensure" files/flatpak/base/etc/systemd/
 test -f files/workstation/shared/usr/libexec/myos-workstation-dm-apply
 
 grep -q 'from-file: layers/shared/workstation-substrate.yml' recipes/layers/shared/workstation-common.yml
+grep -q 'from-file: layers/shared/workstation-media.yml' recipes/layers/shared/workstation-common.yml
 grep -q 'from-file: layers/shared/workstation-admin-tools.yml' recipes/layers/shared/workstation-common.yml
 grep -q 'from-file: layers/shared/workstation-policy.yml' recipes/layers/shared/workstation-common.yml
 grep -q 'from-file: layers/shared/workstation-user-tools.yml' recipes/layers/shared/workstation-common.yml
 ! grep -q 'brave-browser-rpm-beta' recipes/layers/shared/workstation-common.yml
 ! grep -q 'myos-workstation-dm-apply.service' recipes/layers/shared/workstation-common.yml
 grep -q '^        - ModemManager$' recipes/layers/shared/workstation-substrate.yml
+grep -q '^        - libva$' recipes/layers/shared/workstation-media.yml
+grep -q '^        - libvdpau$' recipes/layers/shared/workstation-media.yml
+grep -q '^        - mesa-dri-drivers$' recipes/layers/shared/workstation-media.yml
+grep -q '^        - libva-utils$' recipes/layers/alma9/workstation.yml
+grep -q 'libva-nvidia-driver' recipes/layers/alma9/nvidia-workstation.yml
+! grep -q 'libva-nvidia-driver' recipes/layers/alma9/nvidia-580.yml
 grep -q '^        - tcpdump$' recipes/layers/shared/workstation-admin-tools.yml
 grep -q 'myos-workstation-dm-apply.service' recipes/layers/shared/workstation-policy.yml
 grep -q 'brave-origin-beta' recipes/layers/shared/workstation-user-tools.yml
+test -f files/workstation/user-tools/usr/lib/tmpfiles.d/myos-brave-origin-opt.conf
+grep -Eq '^L\+ /var/opt/brave\.com .*/usr/lib/opt/brave\.com$' files/workstation/user-tools/usr/lib/tmpfiles.d/myos-brave-origin-opt.conf
 
 test -f files/base/runtime/etc/ld.so.conf.d/rocm.conf
 test -f files/base/runtime/etc/profile.d/rocm.sh

--- a/scripts/verify-alma9-nvidia-580.ps1
+++ b/scripts/verify-alma9-nvidia-580.ps1
@@ -4,6 +4,7 @@ Set-StrictMode -Version Latest
 $repoRoot = Split-Path -Parent $PSScriptRoot
 $matrixPath = Join-Path $repoRoot "files/base/runtime/usr/share/myos/image-matrix.tsv"
 $laneLayerPath = Join-Path $repoRoot "recipes/layers/alma9/nvidia-580.yml"
+$workstationVaapiLayerPath = Join-Path $repoRoot "recipes/layers/alma9/nvidia-workstation.yml"
 
 if (-not (Test-Path $laneLayerPath)) {
     throw "Missing Alma 9 NVIDIA 580 layer: $laneLayerPath"
@@ -11,6 +12,10 @@ if (-not (Test-Path $laneLayerPath)) {
 
 if (-not (Test-Path $matrixPath)) {
     throw "Missing image matrix manifest: $matrixPath"
+}
+
+if (-not (Test-Path $workstationVaapiLayerPath)) {
+    throw "Missing Alma 9 NVIDIA workstation VAAPI layer: $workstationVaapiLayerPath"
 }
 
 $laneRows = @(
@@ -71,6 +76,29 @@ $requiredSnippets = @(
 foreach ($snippet in $requiredSnippets) {
     if (-not $laneLayer.Contains($snippet)) {
         throw "Alma 9 NVIDIA 580 layer is missing required snippet: $snippet"
+    }
+}
+
+if ($laneLayer.Contains("libva-nvidia-driver")) {
+    throw "Alma 9 NVIDIA 580 lane layer must stay server-safe; libva-nvidia-driver belongs in alma9/nvidia-workstation.yml."
+}
+
+$workstationVaapiLayer = Get-Content $workstationVaapiLayerPath -Raw
+if (-not $workstationVaapiLayer.Contains("libva-nvidia-driver")) {
+    throw "Alma 9 NVIDIA workstation VAAPI layer must install libva-nvidia-driver."
+}
+
+foreach ($row in $laneRows) {
+    $recipePath = Join-Path $repoRoot $row.recipe
+    $recipeText = Get-Content $recipePath -Raw
+    $hasWorkstationVaapiLayer = $recipeText.Contains("layers/alma9/nvidia-workstation.yml")
+
+    if ($row.role -eq "workstation") {
+        if (-not $hasWorkstationVaapiLayer) {
+            throw "Alma 9 NVIDIA workstation recipe $($row.recipe) must include layers/alma9/nvidia-workstation.yml."
+        }
+    } elseif ($hasWorkstationVaapiLayer) {
+        throw "Alma 9 NVIDIA non-workstation recipe $($row.recipe) must not include layers/alma9/nvidia-workstation.yml."
     }
 }
 


### PR DESCRIPTION
Add a bootc tmpfiles compatibility link for Brave Origin's vendor /opt payload, introduce a shared workstation media runtime layer, and keep Alma9-specific VAAPI diagnostics/backends in Alma9 workstation layers.

Also guard the Alma9 NVIDIA workstation VAAPI backend so it does not leak into the server NVIDIA lane.